### PR TITLE
Loading SimpleMDE on content

### DIFF
--- a/wp-markdown-editor.php
+++ b/wp-markdown-editor.php
@@ -102,7 +102,8 @@ class WpMarkdownEditor
         echo '<script type="text/javascript">
                 // Init the editor
                 var simplemde = new SimpleMDE({
-                    spellChecker: false
+                    spellChecker: false,
+                    element: document.getElementById("content")
                 });
 
                 // Change zIndex when toggle full screen


### PR DESCRIPTION
SimpleMDE loads on the first textare it finds on the page. I changed this to load on the id content so it doesn't interfere with ACF fields.
