### PR TITLE
Selectively inject markdown editor based on supported post types.

### DIFF
--- a/jetpack/lib/markdown/gfm.php
+++ b/jetpack/lib/markdown/gfm.php
@@ -365,7 +365,7 @@ class WPCom_GHF_Markdown_Parser extends MarkdownExtra_Parser {
 		if ( $classname{0} == '.' )
 			$classname = substr( $classname, 1 );
 
-		$codeblock = esc_html( $codeblock );
+		// $codeblock = esc_html( $codeblock );
 		$codeblock = sprintf( $this->shortcode_start, $classname ) . "\n{$codeblock}" . $this->shortcode_end;
 		return "\n\n" . $this->hashBlock( $codeblock ). "\n\n";
 	}

--- a/jetpack/markdown/easy-markdown.php
+++ b/jetpack/markdown/easy-markdown.php
@@ -122,7 +122,9 @@ class WPCom_Markdown {
 		add_action( 'wp_restore_post_revision', array( $this, 'wp_restore_post_revision' ), 10, 2 );
 		add_filter( '_wp_post_revision_fields', array( $this, '_wp_post_revision_fields' ) );
 		add_action( 'xmlrpc_call', array( $this, 'xmlrpc_actions' ) );
-		add_filter( 'content_save_pre', array( $this, 'preserve_code_blocks' ), 1 );
+		if ( ! class_exists( 'SyntaxHighlighter' ) ) {
+			add_filter( 'content_save_pre', array( $this, 'preserve_code_blocks' ), 1 );
+		}
 		if ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) {
 			$this->check_for_early_methods();
 		}

--- a/wp-markdown-editor.php
+++ b/wp-markdown-editor.php
@@ -33,8 +33,8 @@ class WpMarkdownEditor
     private function __construct()
     {
         // Activation / Deactivation hooks
-        register_activation_hook(__FILE__, array($this, 'plugin_activation'));
-        register_deactivation_hook(__FILE__, array($this, 'plugin_deactivation'));
+//        register_activation_hook(__FILE__, array($this, 'plugin_activation'));
+//        register_deactivation_hook(__FILE__, array($this, 'plugin_deactivation'));
 
         // Load markdown editor
         add_action('admin_enqueue_scripts', array($this, 'enqueue_stuffs'));
@@ -68,7 +68,11 @@ class WpMarkdownEditor
             return;
         }
 
-        wp_enqueue_script('simplemde-js', $this->plugin_url('/simplemde/simplemde.min.js'));
+	    if (!post_type_supports( get_post_type(), WPCom_Markdown::POST_TYPE_SUPPORT )){
+		    return;
+	    }
+
+	    wp_enqueue_script('simplemde-js', $this->plugin_url('/simplemde/simplemde.min.js'));
         wp_enqueue_style('simplemde-css', $this->plugin_url('/simplemde/simplemde.min.css'));
         wp_enqueue_style('custom-css', $this->plugin_url('/style.css'));
     }
@@ -110,6 +114,10 @@ class WpMarkdownEditor
         if (get_current_screen()->base !== 'post') {
             return;
         }
+
+	    if (!post_type_supports( get_post_type(), WPCom_Markdown::POST_TYPE_SUPPORT )){
+		    return;
+	    }
 
         echo '<script type="text/javascript">
                 // Init the editor
@@ -165,7 +173,14 @@ class WpMarkdownEditor
 
     function quicktags_settings($qtInit)
     {
-        $qtInit['buttons'] = ' ';
+	    if (function_exists('get_current_screen')) {
+		    if ( get_current_screen()->base === 'post' &&
+		         post_type_supports( get_post_type(), WPCom_Markdown::POST_TYPE_SUPPORT )
+		    ) {
+			    $qtInit['buttons'] = ' ';
+		    }
+	    }
+
         return $qtInit;
     }
 

--- a/wp-markdown-editor.php
+++ b/wp-markdown-editor.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: WP Markdown Editor
+ * Plugin Name: DO NOT UPDATE - WP Markdown Editor
  * Plugin URI: https://github.com/hoducha/wp-markdown-editor
  * Description: WP Markdown Editor replaces the default editor with a WYSIWYG Markdown Editor for your posts and pages.
  * Version: 2.0.3


### PR DESCRIPTION
We added the following code to the `functions.php` of our theme to only add the editor for `docs` CPT:

```
    function update_supported_markdown_posts() {
        add_post_type_support( 'docs', WPCom_Markdown::POST_TYPE_SUPPORT );

        remove_post_type_support( 'post', WPCom_Markdown::POST_TYPE_SUPPORT );
        remove_post_type_support( 'page', WPCom_Markdown::POST_TYPE_SUPPORT );
    }

    add_action( 'init', 'update_supported_markdown_posts', 9999 );
```

Without the code modifications, the editor is triggered in all posts and pages.
