### PR TITLE
fix: editor is covered by Nav and Left Menu when enlarged

### DIFF
--- a/wp-markdown-editor.php
+++ b/wp-markdown-editor.php
@@ -126,8 +126,10 @@ class WpMarkdownEditor
                         var wrap = cm.getWrapperElement();
                         if(/fullscreen/.test(wrap.previousSibling.className)) {
                             document.getElementById("wp-content-editor-container").style.zIndex = 999999;
+                            document.getElementById("wp-content-editor-container").style.position = "absolute";
                         } else {
                             document.getElementById("wp-content-editor-container").style.zIndex = 1;
+                            document.getElementById("wp-content-editor-container").style.position = "initial";
                         }
                     }, 2);
                 }


### PR DESCRIPTION
fix: editor is covered by Nav and Left Menu when enlarged